### PR TITLE
"fogenable", "0"

### DIFF
--- a/addons/sourcemod/scripting/szf/stun.sp
+++ b/addons/sourcemod/scripting/szf/stun.sp
@@ -171,7 +171,7 @@ void Stun_ClientThink(int iClient)
 		iFogEnt = EntIndexToEntRef(CreateEntityByName("env_fog_controller"));
 		DispatchKeyValue(iFogEnt, "fogstart", "256");
 		DispatchKeyValue(iFogEnt, "fogend", "512");
-		DispatchKeyValue(iFogEnt, "fogenable", "1");
+		DispatchKeyValue(iFogEnt, "fogenable", "0");
 		DispatchKeyValue(iFogEnt, "fogcolor", "0 0 0");
 		DispatchKeyValue(iFogEnt, "fogcolor2", "171 177 209");
 		


### PR DESCRIPTION
It disables the spy fog effect on backstab until the permablind fix the pushed.